### PR TITLE
Support multiple input srcFiles and languageFiles

### DIFF
--- a/src/create-report/index.ts
+++ b/src/create-report/index.ts
@@ -26,8 +26,10 @@ export async function createI18NReport(options: ReportOptions): Promise<I18NRepo
   if (!languageFilesGlob) throw new Error('Required configuration languageFiles is missing.');
 
   const dot = typeof separator === 'string' ? new Dot(separator) : Dot;
-  const srcFiles = readSrcFiles(path.resolve(process.cwd(), srcFilesGlob));
-  const languageFiles = readLanguageFiles(path.resolve(process.cwd(), languageFilesGlob));
+  const srcFilesGlobs = !Array.isArray(srcFilesGlob) ? [srcFilesGlob] : srcFilesGlob;
+  const srcFiles = readSrcFiles(srcFilesGlobs.map((glob) => path.resolve(process.cwd(), glob)));
+  const languageFilesGlobs = !Array.isArray(languageFilesGlob) ? [languageFilesGlob] : languageFilesGlob;
+  const languageFiles = readLanguageFiles(languageFilesGlobs.map((glob) => path.resolve(process.cwd(), glob)));
 
   const I18NItems = extractI18NItemsFromSrcFiles(srcFiles);
   const I18NLanguage = extractI18NLanguageFromLanguageFiles(languageFiles, dot);

--- a/src/create-report/language-files.ts
+++ b/src/create-report/language-files.ts
@@ -7,12 +7,16 @@ import isValidGlob from 'is-valid-glob';
 import { SimpleFile, I18NLanguage, I18NItem } from '../types';
 import { sortObject } from './utils';
 
-export function readLanguageFiles(src: string): SimpleFile[] {
+export function readLanguageFiles(src: string | string[]): SimpleFile[] {
   if (!isValidGlob(src)) {
     throw new Error(`languageFiles isn't a valid glob pattern.`);
   }
 
-  const targetFiles = glob.sync(src);
+  if (!Array.isArray(src)) {
+    src = [src];
+  }
+
+  const targetFiles = src.flatMap((targetFile) => glob.sync(targetFile));
 
   if (targetFiles.length === 0) {
     throw new Error('languageFiles glob has no files.');
@@ -129,6 +133,6 @@ function writeLanguageFile(languageFile: SimpleFile, newLanguageFileContent: unk
 }
 
 // This is a convenience function for users implementing in their own projects, and isn't used internally
-export function parselanguageFiles(languageFiles: string, dot: DotObject.Dot = Dot): I18NLanguage {
+export function parselanguageFiles(languageFiles: string | string[], dot: DotObject.Dot = Dot): I18NLanguage {
   return extractI18NLanguageFromLanguageFiles(readLanguageFiles(languageFiles), dot);
 }

--- a/src/create-report/src-files.ts
+++ b/src/create-report/src-files.ts
@@ -3,12 +3,16 @@ import isValidGlob from 'is-valid-glob';
 import glob from 'glob';
 import fs from 'fs';
 
-export function readSrcFiles(src: string): SimpleFile[] {
+export function readSrcFiles(src: string | string[]): SimpleFile[] {
   if (!isValidGlob(src)) {
     throw new Error(`srcFiles isn't a valid glob pattern.`);
   }
 
-  const targetFiles = glob.sync(src);
+  if (!Array.isArray(src)) {
+    src = [src];
+  }
+
+  const targetFiles = src.flatMap((targetFile) => glob.sync(targetFile)).sort((a, b) => (a > b ? -1 : 1));
 
   if (targetFiles.length === 0) {
     throw new Error('srcFiles glob has no files.');
@@ -92,6 +96,6 @@ export function extractI18NItemsFromSrcFiles(sourceFiles: SimpleFile[]): I18NIte
 }
 
 // This is a convenience function for users implementing in their own projects, and isn't used internally
-export function parseSrcFiles(srcFiles: string): I18NItemWithBounding[] {
+export function parseSrcFiles(srcFiles: string | string[]): I18NItemWithBounding[] {
   return extractI18NItemsFromSrcFiles(readSrcFiles(srcFiles));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type ReportOptions = {
-  srcFiles: string;
-  languageFiles: string;
+  srcFiles: string | string[];
+  languageFiles: string | string[];
   output?: string;
   add?: boolean;
   remove?: boolean;

--- a/tests/fixtures/expected-values.ts
+++ b/tests/fixtures/expected-values.ts
@@ -1,115 +1,31 @@
 export const expectedFromParsedSrcFiles = [
   {
-    path: 'header.title',
+    path: 'header.paragraphs.p_1',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 3
+    file: './tests/fixtures/src-files/js-component.js',
+    line: 2
   },
   {
-    path: 'header.title2',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 4
-  },
-  {
-    path: 'content.paragraph.p_1',
-    previousCharacter: '"',
-    nextCharacter: '"',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 5
-  },
-  {
-    path: 'Key used as default translation. Second sentence.',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 6
-  },
-  {
-    path: 'content.paragraph.p.2',
+    path: 'dynamic_${object?.code?.toUpperCase()}_key',
     previousCharacter: '`',
     nextCharacter: '`',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 7
-  },
-  {
-    path: 'content.link.b',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 9
-  },
-  {
-    path: 'content.link.b',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 12
-  },
-  {
-    path: 'content.link.b',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 15
+    file: './tests/fixtures/src-files/js-component.js',
+    line: 2
   },
   {
     path: 'header.title',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 18
-  },
-  {
-    path: 'content.img.src_${var}',
-    nextCharacter: '`',
-    previousCharacter: '`',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 19
-  },
-  {
-    path: 'CONTINENT_NAME_${this.origin.country_code}',
-    nextCharacter: '`',
-    previousCharacter: '`',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 20
-  },
-  {
-    path: 'AUTO_bcc_${fieldName.toUpperCase()}_${mode.toUpperCase()}',
-    nextCharacter: '`',
-    previousCharacter: '`',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 21
-  },
-  {
-    path: 'content.link.a',
-    previousCharacter: '"',
-    nextCharacter: '"',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 8
-  },
-  {
-    path: 'content.link.a',
-    previousCharacter: '"',
-    nextCharacter: '"',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 11
-  },
-  {
-    path: 'content.link.a',
-    previousCharacter: '"',
-    nextCharacter: '"',
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 14
+    file: './tests/fixtures/src-files/folder1/folder2/Deep.vue',
+    line: 2
   },
   {
     path: 'header.title',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/Basic.vue',
-    line: 17
+    file: './tests/fixtures/src-files/folder1/Nested.vue',
+    line: 2
   },
   {
     path: "single \\' quote",
@@ -189,18 +105,18 @@ export const expectedFromParsedSrcFiles = [
     line: 16
   },
   {
-    path: 'header.title',
+    path: 'missing.english',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/folder1/folder2/Deep.vue',
-    line: 2
+    file: './tests/fixtures/src-files/Missing.vue',
+    line: 3
   },
   {
-    path: 'header.title',
+    path: 'missing.german',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/folder1/Nested.vue',
-    line: 2
+    file: './tests/fixtures/src-files/Missing.vue',
+    line: 4
   },
   {
     path: 'header.title',
@@ -238,32 +154,116 @@ export const expectedFromParsedSrcFiles = [
     line: 35
   },
   {
-    path: 'header.paragraphs.p_1',
+    path: 'header.title',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/js-component.js',
-    line: 2
-  },
-  {
-    path: 'dynamic_${object?.code?.toUpperCase()}_key',
-    nextCharacter: '`',
-    previousCharacter: '`',
-    file: './tests/fixtures/src-files/js-component.js',
-    line: 2
-  },
-  {
-    path: 'missing.english',
-    previousCharacter: "'",
-    nextCharacter: "'",
-    file: './tests/fixtures/src-files/Missing.vue',
+    file: './tests/fixtures/src-files/Basic.vue',
     line: 3
   },
   {
-    path: 'missing.german',
+    path: 'header.title2',
     previousCharacter: "'",
     nextCharacter: "'",
-    file: './tests/fixtures/src-files/Missing.vue',
+    file: './tests/fixtures/src-files/Basic.vue',
     line: 4
+  },
+  {
+    path: 'content.paragraph.p_1',
+    previousCharacter: '"',
+    nextCharacter: '"',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 5
+  },
+  {
+    path: 'Key used as default translation. Second sentence.',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 6
+  },
+  {
+    path: 'content.paragraph.p.2',
+    previousCharacter: '`',
+    nextCharacter: '`',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 7
+  },
+  {
+    path: 'content.link.b',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 9
+  },
+  {
+    path: 'content.link.b',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 12
+  },
+  {
+    path: 'content.link.b',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 15
+  },
+  {
+    path: 'header.title',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 18
+  },
+  {
+    path: 'content.img.src_${var}',
+    previousCharacter: '`',
+    nextCharacter: '`',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 19
+  },
+  {
+    path: 'CONTINENT_NAME_${this.origin.country_code}',
+    previousCharacter: '`',
+    nextCharacter: '`',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 20
+  },
+  {
+    path: 'AUTO_bcc_${fieldName.toUpperCase()}_${mode.toUpperCase()}',
+    previousCharacter: '`',
+    nextCharacter: '`',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 21
+  },
+  {
+    path: 'content.link.a',
+    previousCharacter: '"',
+    nextCharacter: '"',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 8
+  },
+  {
+    path: 'content.link.a',
+    previousCharacter: '"',
+    nextCharacter: '"',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 11
+  },
+  {
+    path: 'content.link.a',
+    previousCharacter: '"',
+    nextCharacter: '"',
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 14
+  },
+  {
+    path: 'header.title',
+    previousCharacter: "'",
+    nextCharacter: "'",
+    file: './tests/fixtures/src-files/Basic.vue',
+    line: 17
   }
 ];
 
@@ -392,6 +392,12 @@ export const expectedFromParsedLanguageFiles = {
 export const expectedI18NReport = {
   missingKeys: [
     {
+      path: 'header.paragraphs.p_1',
+      file: './tests/fixtures/src-files/js-component.js',
+      line: 2,
+      language: 'de_DE'
+    },
+    {
       path: "single \\' quote",
       file: './tests/fixtures/src-files/edge-cases.js',
       line: 2,
@@ -449,12 +455,6 @@ export const expectedI18NReport = {
       path: 'leading tab',
       file: './tests/fixtures/src-files/edge-cases.js',
       line: 13,
-      language: 'de_DE'
-    },
-    {
-      path: 'header.paragraphs.p_1',
-      file: './tests/fixtures/src-files/js-component.js',
-      line: 2,
       language: 'de_DE'
     },
     {
@@ -464,6 +464,12 @@ export const expectedI18NReport = {
       language: 'de_DE'
     },
     {
+      path: 'header.paragraphs.p_1',
+      file: './tests/fixtures/src-files/js-component.js',
+      line: 2,
+      language: 'en_EN'
+    },
+    {
       path: "single \\' quote",
       file: './tests/fixtures/src-files/edge-cases.js',
       line: 2,
@@ -521,12 +527,6 @@ export const expectedI18NReport = {
       path: 'leading tab',
       file: './tests/fixtures/src-files/edge-cases.js',
       line: 13,
-      language: 'en_EN'
-    },
-    {
-      path: 'header.paragraphs.p_1',
-      file: './tests/fixtures/src-files/js-component.js',
-      line: 2,
       language: 'en_EN'
     },
     {
@@ -558,6 +558,16 @@ export const expectedI18NReport = {
   ],
   maybeDynamicKeys: [
     {
+      path: 'dynamic_${object?.code?.toUpperCase()}_key',
+      file: './tests/fixtures/src-files/js-component.js',
+      line: 2
+    },
+    {
+      path: '${dynamicKey}',
+      file: './tests/fixtures/src-files/edge-cases.js',
+      line: 16
+    },
+    {
       path: 'content.img.src_${var}',
       file: './tests/fixtures/src-files/Basic.vue',
       line: 19
@@ -571,16 +581,6 @@ export const expectedI18NReport = {
       path: 'AUTO_bcc_${fieldName.toUpperCase()}_${mode.toUpperCase()}',
       file: './tests/fixtures/src-files/Basic.vue',
       line: 21
-    },
-    {
-      path: '${dynamicKey}',
-      file: './tests/fixtures/src-files/edge-cases.js',
-      line: 16
-    },
-    {
-      path: 'dynamic_${object?.code?.toUpperCase()}_key',
-      file: './tests/fixtures/src-files/js-component.js',
-      line: 2
     }
   ]
 };

--- a/tests/fixtures/resolved-sources.ts
+++ b/tests/fixtures/resolved-sources.ts
@@ -1,4 +1,13 @@
 import path from 'path';
 
 export const srcFiles = path.resolve(__dirname, './src-files/**/*.?(js|vue)');
+export const srcFilesArray = [
+  path.resolve(__dirname, './src-files/**/*.vue'),
+  path.resolve(__dirname, './src-files/**/*.js')
+];
 export const languageFiles = path.resolve(__dirname, './lang/**/*.?(js|json|yml|yaml)');
+export const languageFilesArray = [
+  path.resolve(__dirname, './lang/**/*.js'),
+  path.resolve(__dirname, './lang/**/*.yml'),
+  path.resolve(__dirname, './lang/**/*.?(json|yaml)')
+];

--- a/tests/unit/create-report/language-files.spec.ts
+++ b/tests/unit/create-report/language-files.spec.ts
@@ -8,7 +8,7 @@ import {
   parselanguageFiles
 } from '@/create-report/language-files';
 import { expectedFromParsedLanguageFiles, expectedI18NReport } from '../../fixtures/expected-values';
-import { languageFiles } from '../../fixtures/resolved-sources';
+import { languageFiles, languageFilesArray } from '../../fixtures/resolved-sources';
 
 describe('file: create-report/language-files', () => {
   describe('function: parselanguageFiles', () => {
@@ -17,14 +17,19 @@ describe('file: create-report/language-files', () => {
       expect(I18NLanguage).toEqual(expectedFromParsedLanguageFiles);
     });
 
+    it('accepts multiple file globs passed as arguments', () => {
+      const I18NLanguage = parselanguageFiles(languageFilesArray);
+      expect(I18NLanguage).toEqual(expectedFromParsedLanguageFiles);
+    });
+
     it('Throws an error if it is not a valid glob', () => {
       const brokenLanguageSource = '';
-      expect(() => readLanguageFiles(brokenLanguageSource)).toThrow(`languageFiles isn't a valid glob pattern.`);
+      expect(() => readLanguageFiles([brokenLanguageSource])).toThrow(`languageFiles isn't a valid glob pattern.`);
     });
 
     it('Throws an error if it does not find any file', () => {
       const brokenLanguageSource = path.resolve(__dirname, '../fixtures/language-files/**/*.txt');
-      expect(() => readLanguageFiles(brokenLanguageSource)).toThrow('languageFiles glob has no files.');
+      expect(() => readLanguageFiles([brokenLanguageSource])).toThrow('languageFiles glob has no files.');
     });
   });
 
@@ -33,7 +38,7 @@ describe('file: create-report/language-files', () => {
       const writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync');
       writeFileSyncSpy.mockImplementation(() => jest.fn());
       const dotStrSpy = jest.spyOn(dot, 'str');
-      writeMissingToLanguageFiles(readLanguageFiles(languageFiles), expectedI18NReport.missingKeys);
+      writeMissingToLanguageFiles(readLanguageFiles([languageFiles]), expectedI18NReport.missingKeys);
       expect(dotStrSpy).toHaveBeenCalledTimes(36);
       expect(writeFileSyncSpy).toHaveBeenCalledTimes(3);
       expect(writeFileSyncSpy.mock.calls[0][1]).toContain('missing');
@@ -46,7 +51,7 @@ describe('file: create-report/language-files', () => {
       writeFileSyncSpy.mockImplementation(() => jest.fn());
       jest.resetAllMocks();
       const dotDeleteSpy = jest.spyOn(dot, 'delete');
-      removeUnusedFromLanguageFiles(readLanguageFiles(languageFiles), expectedI18NReport.unusedKeys);
+      removeUnusedFromLanguageFiles(readLanguageFiles([languageFiles]), expectedI18NReport.unusedKeys);
       expect(dotDeleteSpy).toHaveBeenCalledTimes(5);
       expect(writeFileSyncSpy).toHaveBeenCalledTimes(3);
       expect(writeFileSyncSpy.mock.calls[0][1]).not.toContain('unused');

--- a/tests/unit/create-report/src-files.spec.ts
+++ b/tests/unit/create-report/src-files.spec.ts
@@ -1,12 +1,18 @@
 import { readSrcFiles, parseSrcFiles } from '@/create-report/src-files';
 import { expectedFromParsedSrcFiles } from '../../fixtures/expected-values';
-import { srcFiles } from '../../fixtures/resolved-sources';
+import { srcFiles, srcFilesArray } from '../../fixtures/resolved-sources';
 import path from 'path';
 
 describe('file: create-report/src-files', () => {
   describe('function: parseSrcFiles', () => {
     it('Parse the file glob into I18n items', () => {
       const I18NItems = parseSrcFiles(srcFiles);
+      expect(I18NItems).toEqual(expectedFromParsedSrcFiles);
+    });
+
+    it('accepts multiple file globs passed as arguments', () => {
+      const I18NItems = parseSrcFiles(srcFilesArray);
+      expect(I18NItems.length).toEqual(expectedFromParsedSrcFiles.length);
       expect(I18NItems).toEqual(expectedFromParsedSrcFiles);
     });
 


### PR DESCRIPTION
Specifying multiple glob patterns for srcFiles and languageFiles would allow users to pull multiple language files from different locations in a more flexible way than with a single glob pattern.

One use case is when you need to check for translation strings from a parent project in a subproject.