### PR TITLE
Detect duplicated keys in language files

### DIFF
--- a/bin/i18n-utils.js
+++ b/bin/i18n-utils.js
@@ -27,6 +27,10 @@ cli
     '[boolean] The process will exit with exitCode=1 if at least one translation-key is missing (useful expecially if it is part of a CI pipeline).'
   )
   .option(
+    '--detect-duplicates',
+    '[boolean] The process will exit with exitCode=1 if at least one translation-key is found in multiple language files for the same locale.'
+  )
+  .option(
     '--separator <separator>',
     'Use if you want to override the separator used when parsing locale identifiers. Default is `.`'
   )

--- a/src/config-file/i18n-utils.config.ts
+++ b/src/config-file/i18n-utils.config.ts
@@ -7,5 +7,6 @@ export default {
   remove: false,
   normalize: false,
   ci: false,
-  separator: '.'
+  separator: '.',
+  detectDuplicates: false
 };

--- a/src/create-report/index.ts
+++ b/src/create-report/index.ts
@@ -19,7 +19,8 @@ export async function createI18NReport(options: ReportOptions): Promise<I18NRepo
     remove,
     normalize,
     ci,
-    separator
+    separator,
+    detectDuplicates
   } = options;
 
   if (!srcFilesGlob) throw new Error('Required configuration srcFiles is missing.');
@@ -38,6 +39,7 @@ export async function createI18NReport(options: ReportOptions): Promise<I18NRepo
 
   if (report.missingKeys.length) console.info('\nMissing Keys'), console.table(report.missingKeys);
   if (report.unusedKeys.length) console.info('\nUnused Keys'), console.table(report.unusedKeys);
+  if (report.duplicatedKeys.length) console.info('\nDuplicated Keys'), console.table(report.duplicatedKeys);
   if (report.maybeDynamicKeys.length)
     console.warn(
       "\nSuspected Dynamic Keys Found\ni18n-utils is extra cautious and won't consider any matching key as 'unused'."
@@ -64,6 +66,10 @@ export async function createI18NReport(options: ReportOptions): Promise<I18NRepo
 
   if (ci && report.unusedKeys.length) {
     throw new Error(`${report.unusedKeys.length} unused keys found.`);
+  }
+
+  if (detectDuplicates && report.duplicatedKeys.length) {
+    throw new Error(`${report.duplicatedKeys.length} duplicated keys found.`);
   }
 
   return report;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type ReportOptions = {
   normalize?: boolean;
   ci?: boolean;
   separator?: string;
+  detectDuplicates?: boolean;
 };
 
 export type SimpleFile = {
@@ -22,6 +23,12 @@ export type I18NItem = {
   language?: string;
 };
 
+export type I18NDuplicatedItem = {
+  path: string;
+  language: string;
+  files: string[];
+};
+
 export type I18NItemWithBounding = I18NItem & {
   previousCharacter: string;
   nextCharacter: string;
@@ -34,5 +41,6 @@ export type I18NLanguage = {
 export type I18NReport = {
   missingKeys: I18NItem[];
   unusedKeys: I18NItem[];
+  duplicatedKeys: I18NDuplicatedItem[];
   maybeDynamicKeys: I18NItem[];
 };

--- a/tests/fixtures/expected-values.ts
+++ b/tests/fixtures/expected-values.ts
@@ -310,6 +310,11 @@ export const expectedFromParsedLanguageFiles = {
       line: 7
     },
     {
+      path: 'duplicated_key',
+      file: './tests/fixtures/lang/de_DE.js',
+      line: 8
+    },
+    {
       path: 'content.paragraph.p_1',
       file: './tests/fixtures/lang/de_DE.yaml',
       line: 0
@@ -318,6 +323,11 @@ export const expectedFromParsedLanguageFiles = {
       path: 'unused_yaml',
       file: './tests/fixtures/lang/de_DE.yaml',
       line: 1
+    },
+    {
+      path: 'duplicated_key',
+      file: './tests/fixtures/lang/de_DE.yaml',
+      line: 2
     }
   ],
   en_EN: [
@@ -544,9 +554,21 @@ export const expectedI18NReport = {
       language: 'de_DE'
     },
     {
+      path: 'duplicated_key',
+      file: './tests/fixtures/lang/de_DE.js',
+      line: 8,
+      language: 'de_DE'
+    },
+    {
       path: 'unused_yaml',
       file: './tests/fixtures/lang/de_DE.yaml',
       line: 1,
+      language: 'de_DE'
+    },
+    {
+      path: 'duplicated_key',
+      file: './tests/fixtures/lang/de_DE.yaml',
+      line: 2,
       language: 'de_DE'
     },
     {
@@ -554,6 +576,13 @@ export const expectedI18NReport = {
       file: './tests/fixtures/lang/en_EN.json',
       line: 9,
       language: 'en_EN'
+    }
+  ],
+  duplicatedKeys: [
+    {
+      path: 'duplicated_key',
+      files: ['./tests/fixtures/lang/de_DE.js', './tests/fixtures/lang/de_DE.yaml'],
+      language: 'de_DE'
     }
   ],
   maybeDynamicKeys: [

--- a/tests/fixtures/lang/de_DE.js
+++ b/tests/fixtures/lang/de_DE.js
@@ -16,5 +16,6 @@ module.exports = {
   missing: {
     english: 'Missing!'
   },
-  unused_js: 'This key is unused.'
+  unused_js: 'This key is unused.',
+  duplicated_key: 'This key is also declared in the yaml file'
 };

--- a/tests/fixtures/lang/de_DE.yaml
+++ b/tests/fixtures/lang/de_DE.yaml
@@ -2,3 +2,4 @@ content:
   paragraph:
     p_1: Clicked {count} times
 unused_yaml: unused
+duplicated_key: 'This key is also declared in the js file'

--- a/tests/unit/create-report/index.spec.ts
+++ b/tests/unit/create-report/index.spec.ts
@@ -33,9 +33,10 @@ describe('file: create-report/index', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       "\nSuspected Dynamic Keys Found\ni18n-utils is extra cautious and won't consider any matching key as 'unused'."
     );
-    expect(consoleTableSpy).toHaveBeenCalledTimes(3);
+    expect(consoleTableSpy).toHaveBeenCalledTimes(4);
     expect(consoleTableSpy.mock.calls[0][0]).toEqual(expectedI18NReport.missingKeys);
     expect(consoleTableSpy.mock.calls[1][0]).toEqual(expectedI18NReport.unusedKeys);
+    expect(consoleTableSpy.mock.calls[2][0]).toEqual(expectedI18NReport.duplicatedKeys);
   });
 
   it('Write report to file at output path', async () => {

--- a/tests/unit/create-report/language-files.spec.ts
+++ b/tests/unit/create-report/language-files.spec.ts
@@ -52,7 +52,7 @@ describe('file: create-report/language-files', () => {
       jest.resetAllMocks();
       const dotDeleteSpy = jest.spyOn(dot, 'delete');
       removeUnusedFromLanguageFiles(readLanguageFiles([languageFiles]), expectedI18NReport.unusedKeys);
-      expect(dotDeleteSpy).toHaveBeenCalledTimes(5);
+      expect(dotDeleteSpy).toHaveBeenCalledTimes(9);
       expect(writeFileSyncSpy).toHaveBeenCalledTimes(3);
       expect(writeFileSyncSpy.mock.calls[0][1]).not.toContain('unused');
     });


### PR DESCRIPTION
Duplicated keys should not appear across different language files for the same language, this adds the logic to detect such duplicates.

Below is how the output looks like with this new table of duplicated keys found.

Also adds the ability to make the CLI tool fail as soon as it encounters a duplicated key in a language file using the `--detect-duplicates` flag. We could make this flag part of the already existing `--ci` flag though. 

```
$ i18n-utils --srcFiles './src-files/**/*.?(js|vue)' --languageFiles './lang/**/*.?(js|yaml|json)' --detect-duplicates

Missing Keys
┌─────────┬─────────────────────────┬───────────────────────────────┬──────┬──────────┐
│ (index) │          path           │             file              │ line │ language │
├─────────┼─────────────────────────┼───────────────────────────────┼──────┼──────────┤
│    0    │ 'header.paragraphs.p_1' │ './src-files/js-component.js' │  2   │ 'de_DE'  │
│    1    │   "single \\' quote"    │  './src-files/edge-cases.js'  │  2   │ 'de_DE'  │
│    2    │   'single \\" quote'    │  './src-files/edge-cases.js'  │  3   │ 'de_DE'  │
│    3    │     'back \\` tick'     │  './src-files/edge-cases.js'  │  4   │ 'de_DE'  │
│    4    │        'Early '         │  './src-files/edge-cases.js'  │  5   │ 'de_DE'  │
│    5    │      'parentheses'      │  './src-files/edge-cases.js'  │  7   │ 'de_DE'  │
│    6    │    'square brackets'    │  './src-files/edge-cases.js'  │  8   │ 'de_DE'  │
│    7    │    'curly brackets'     │  './src-files/edge-cases.js'  │  9   │ 'de_DE'  │
│    8    │         'colon'         │  './src-files/edge-cases.js'  │  10  │ 'de_DE'  │
│    9    │     'concatenation'     │  './src-files/edge-cases.js'  │  12  │ 'de_DE'  │
│   10    │      'leading tab'      │  './src-files/edge-cases.js'  │  13  │ 'de_DE'  │
│   11    │    'missing.german'     │   './src-files/Missing.vue'   │  4   │ 'de_DE'  │
│   12    │ 'header.paragraphs.p_1' │ './src-files/js-component.js' │  2   │ 'en_EN'  │
│   13    │   "single \\' quote"    │  './src-files/edge-cases.js'  │  2   │ 'en_EN'  │
│   14    │   'single \\" quote'    │  './src-files/edge-cases.js'  │  3   │ 'en_EN'  │
│   15    │     'back \\` tick'     │  './src-files/edge-cases.js'  │  4   │ 'en_EN'  │
│   16    │        'Early '         │  './src-files/edge-cases.js'  │  5   │ 'en_EN'  │
│   17    │      'parentheses'      │  './src-files/edge-cases.js'  │  7   │ 'en_EN'  │
│   18    │    'square brackets'    │  './src-files/edge-cases.js'  │  8   │ 'en_EN'  │
│   19    │    'curly brackets'     │  './src-files/edge-cases.js'  │  9   │ 'en_EN'  │
│   20    │         'colon'         │  './src-files/edge-cases.js'  │  10  │ 'en_EN'  │
│   21    │     'concatenation'     │  './src-files/edge-cases.js'  │  12  │ 'en_EN'  │
│   22    │      'leading tab'      │  './src-files/edge-cases.js'  │  13  │ 'en_EN'  │
│   23    │    'missing.english'    │   './src-files/Missing.vue'   │  3   │ 'en_EN'  │
└─────────┴─────────────────────────┴───────────────────────────────┴──────┴──────────┘

Unused Keys
┌─────────┬──────────────────┬─────────────────────┬──────┬──────────┐
│ (index) │       path       │        file         │ line │ language │
├─────────┼──────────────────┼─────────────────────┼──────┼──────────┤
│    0    │   'unused_js'    │  './lang/de_DE.js'  │  7   │ 'de_DE'  │
│    1    │ 'duplicated_key' │  './lang/de_DE.js'  │  8   │ 'de_DE'  │
│    2    │  'unused_yaml'   │ './lang/de_DE.yaml' │  1   │ 'de_DE'  │
│    3    │ 'duplicated_key' │ './lang/de_DE.yaml' │  2   │ 'de_DE'  │
│    4    │  'unused_json'   │ './lang/en_EN.json' │  9   │ 'en_EN'  │
└─────────┴──────────────────┴─────────────────────┴──────┴──────────┘

Duplicated Keys
┌─────────┬──────────────────┬────────────────────────────────────────────┬──────────┐
│ (index) │       path       │                   files                    │ language │
├─────────┼──────────────────┼────────────────────────────────────────────┼──────────┤
│    0    │ 'duplicated_key' │ [ './lang/de_DE.js', './lang/de_DE.yaml' ] │ 'de_DE'  │
└─────────┴──────────────────┴────────────────────────────────────────────┴──────────┘

Suspected Dynamic Keys Found
i18n-utils is extra cautious and won't consider any matching key as 'unused'.
┌─────────┬─────────────────────────────────────────────────────────────┬───────────────────────────────┬──────┐
│ (index) │                            path                             │             file              │ line │
├─────────┼─────────────────────────────────────────────────────────────┼───────────────────────────────┼──────┤
│    0    │        'dynamic_${object?.code?.toUpperCase()}_key'         │ './src-files/js-component.js' │  2   │
│    1    │                       '${dynamicKey}'                       │  './src-files/edge-cases.js'  │  16  │
│    2    │                  'content.img.src_${var}'                   │    './src-files/Basic.vue'    │  19  │
│    3    │        'CONTINENT_NAME_${this.origin.country_code}'         │    './src-files/Basic.vue'    │  20  │
│    4    │ 'AUTO_bcc_${fieldName.toUpperCase()}_${mode.toUpperCase()}' │    './src-files/Basic.vue'    │  21  │
└─────────┴─────────────────────────────────────────────────────────────┴───────────────────────────────┴──────┘
[i18n-utils] Error: 1 duplicated keys found.
    at createI18NReport (/***/Workspace/i18n-utils/dist/i18n-utils.umd.js:425:13)
    at CAC.<anonymous> (/***/Workspace/i18n-utils/bin/i18n-utils.js:38:5)
    at CAC.runMatchedCommand (/***/Workspace/i18n-utils/node_modules/cac/dist/index.js:614:34)
    at CAC.parse (/***/Workspace/i18n-utils/node_modules/cac/dist/index.js:541:12)
    at Object.<anonymous> (/***/Workspace/i18n-utils/bin/i18n-utils.js:45:5)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
```